### PR TITLE
Feature/main class

### DIFF
--- a/build.fan
+++ b/build.fan
@@ -18,10 +18,11 @@ class Build : BuildPod {
 		depends = [
 			"sys      1.0.68 - 1.0",
 			"fandoc   1.0.68 - 1.0",
-			"afPegger 0.1.0  - 0.1"
+			"afPegger 0.1.0  - 0.1",
+      "util     1.0"
 		]
 
-		srcDirs = [`fan/`, `test/`]
+		srcDirs = [`test/`, `fan/`]
 		resDirs = [`doc/`]
 	}
 }

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -69,7 +69,7 @@ class Main : AbstractMain
     markdownDoc.write( FandocDocWriter( buf.out ) )
     log.debug( buf.toStr )
     log.info( "Done" )
-    return buf.close ? 0 : -1
+    return buf.close ? 0 : 1
   }
   
   
@@ -81,7 +81,7 @@ class Main : AbstractMain
     fandocDoc.write( MarkdownDocWriter( buf.out ) )
     log.debug( buf.toStr )
     log.info( "Done" )
-    return buf.close ? 0 : -1
+    return buf.close ? 0 : 1
   }
   
 }

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -8,52 +8,64 @@ class Main : AbstractMain
   File? srcFile
   
   @Opt { aliases=["l"]; help = "Sets the logging level to any of [silent, err, warn, info, debug]." }
-  LogLevel loggingLevel := LogLevel.info
+  LogLevel logLevel := LogLevel.info
   
+  
+  File? outputFile
   
   
   override Int run()
   {
-    log.level = loggingLevel
+    log.level = logLevel
+    log.info( "Log level: ${log.level}" )
     
     ext := srcFile.ext
     if( ext == null ) { throw Err( "Source file must have either .md (Markdown) or .fandoc (Fandoc) extension." ) }
-    
-        mdLines := srcFile.open( "r" ).readAllLines
-    content := ""
-    mdLines.each {
-      content = content + "\r\n" + it
-    }
-    
-    log.debug( content )
     
     exitCode := 0
    
     switch( ext.lower )
     {
-      case "md": exitCode = parseMarkdown( content )
-      case "fandoc": exitCode = parseFandoc( content )
+      case "md": exitCode = parseMarkdown
+      case "fandoc": exitCode = parseFandoc
       default: throw Err( "Unsupported file extension: .${ext}; only .md and .fandoc files are supported." )
     }
     return exitCode
   }
   
   
-  Int parseMarkdown( Str mdContent )
+  Str readInput()
   {
-    markdownDoc := MarkdownParser().parse( mdContent )
-    
-    buf := StrBuf()
-    markdownDoc.write( FandocDocWriter( buf.out ) )
-
-    log.info( buf.toStr )
-    return 0
+    log.info( "Reading source file ${srcFile}" )
+    content := srcFile.readAllBuf.in.readAllStr
+    log.debug( content )
+    return content
   }
   
   
-  Int parseFandoc( Str fandocContent )
+  Buf getOutputBuffer( Str ext )
   {
-    log.info( fandocContent )
+    outputFile = File( Uri( srcFile.basename + ".${ext}" ) )
+    log.info( "Creating output file ${outputFile}" )
+    return outputFile.open( "rw" )
+  }
+  
+  
+  Int parseMarkdown()
+  {
+    markdownDoc := MarkdownParser().parse( readInput )
+    log.info( "Markdown file parsed" )
+    buf := getOutputBuffer( "fandoc" )
+    markdownDoc.write( FandocDocWriter( buf.out ) )
+    log.debug( buf.toStr )
+    log.info( "Done" )
+    return buf.close ? 0 : -1
+  }
+  
+  
+  Int parseFandoc()
+  {
+    readInput
     return 0
   }
   

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -43,7 +43,7 @@ class Main : AbstractMain
   Str readInput()
   {
     log.info( "Reading source file ${srcFile}" )
-    content := srcFile.readAllBuf.in.readAllStr
+    content := srcFile.readAllStr
     log.debug( content )
     return content
   }

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -51,8 +51,10 @@ class Main : AbstractMain
   
   Buf getOutputBuffer( Str ext )
   {
-    targetFilename := targetFile != null ? targetFile[ 0 ] : srcFile.basename + ".${ext}"
-    outputFile = File( Uri( targetFilename ) )
+    uri := targetFile != null 
+      ? Uri( targetFile[ 0 ] ) 
+      : srcFile.uri.plusName( srcFile.basename + ".${ext}" )
+    outputFile = File( uri )
     if( outputFile.exists && !overwrite ) { throw Err( "Process aborted because the target file exists `${outputFile}`. Use option -o to overwrite." ) }
     log.info( "Creating output file `${outputFile}`" )
     return outputFile.open( "rw" )

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -7,7 +7,10 @@ class Main : AbstractMain
   @Arg { help = "Source Markdown (.md) or Fandoc (.fandoc) file to convert." }
   File? srcFile
   
-  @Opt { aliases=["l"]; help = "Sets the logging level to any of [silent, err, warn, info, debug]." }
+  @Opt { aliases=[ "o" ]; help = "Overwrite target file if exists. By default aborts the process if the target file exists." }
+  Bool overwrite := false
+  
+  @Opt { aliases=[ "l" ]; help = "Sets the logging level to any of [silent, err, warn, info, debug]." }
   LogLevel logLevel := LogLevel.info
   
   
@@ -46,16 +49,17 @@ class Main : AbstractMain
   Buf getOutputBuffer( Str ext )
   {
     outputFile = File( Uri( srcFile.basename + ".${ext}" ) )
-    log.info( "Creating output file ${outputFile}" )
+    if( outputFile.exists && !overwrite ) { throw Err( "Process aborted because the target file exists `${outputFile}`. Use option -o to overwrite." ) }
+    log.info( "Creating output file `${outputFile}`" )
     return outputFile.open( "rw" )
   }
   
   
   Int parseMarkdown()
   {
+    buf := getOutputBuffer( "fandoc" )
     markdownDoc := MarkdownParser().parse( readInput )
     log.info( "Markdown file parsed" )
-    buf := getOutputBuffer( "fandoc" )
     markdownDoc.write( FandocDocWriter( buf.out ) )
     log.debug( buf.toStr )
     log.info( "Done" )

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -67,6 +67,7 @@ class Main : AbstractMain
     log.info( "Markdown file parsed" )
     buf := getOutputBuffer( "fandoc" )
     markdownDoc.write( FandocDocWriter( buf.out ) )
+    buf.sync
     log.debug( buf.toStr )
     log.info( "Done" )
     return buf.close ? 0 : 1
@@ -80,6 +81,7 @@ class Main : AbstractMain
     log.info( "Fandoc file parsed" )
     buf := getOutputBuffer( "md" )
     fandocDoc.write( MarkdownDocWriter( buf.out ) )
+    buf.sync
     log.debug( buf.toStr )
     log.info( "Done" )
     return buf.close ? 0 : 1

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -7,6 +7,9 @@ class Main : AbstractMain
   @Arg { help = "Source Markdown (.md) or Fandoc (.fandoc) file to convert." }
   File? srcFile
   
+  @Arg { help = "Name of the destination file. Defaults to source filename with the opposite extension." }
+  Str[]? targetFile
+  
   @Opt { aliases=[ "o" ]; help = "Overwrite target file if exists. By default aborts the process if the target file exists." }
   Bool overwrite := false
   
@@ -48,7 +51,8 @@ class Main : AbstractMain
   
   Buf getOutputBuffer( Str ext )
   {
-    outputFile = File( Uri( srcFile.basename + ".${ext}" ) )
+    targetFilename := targetFile != null ? targetFile[ 0 ] : srcFile.basename + ".${ext}"
+    outputFile = File( Uri( targetFilename ) )
     if( outputFile.exists && !overwrite ) { throw Err( "Process aborted because the target file exists `${outputFile}`. Use option -o to overwrite." ) }
     log.info( "Creating output file `${outputFile}`" )
     return outputFile.open( "rw" )

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -42,7 +42,7 @@ class Main : AbstractMain
   
   Str readInput()
   {
-    log.info( "Reading source file ${srcFile}" )
+    log.info( "Reading source file `${srcFile}`" )
     content := srcFile.readAllStr
     log.debug( content )
     return content
@@ -63,9 +63,9 @@ class Main : AbstractMain
   
   Int parseMarkdown()
   {
-    buf := getOutputBuffer( "fandoc" )
     markdownDoc := MarkdownParser().parse( readInput )
     log.info( "Markdown file parsed" )
+    buf := getOutputBuffer( "fandoc" )
     markdownDoc.write( FandocDocWriter( buf.out ) )
     log.debug( buf.toStr )
     log.info( "Done" )
@@ -75,9 +75,10 @@ class Main : AbstractMain
   
   Int parseFandoc()
   {
-    buf := getOutputBuffer( "md" )
+    log.info( "Reading source file `${srcFile}`" )
     fandocDoc := FandocParser().parse( srcFile.name, srcFile.in )
     log.info( "Fandoc file parsed" )
+    buf := getOutputBuffer( "md" )
     fandocDoc.write( MarkdownDocWriter( buf.out ) )
     log.debug( buf.toStr )
     log.info( "Done" )

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -73,8 +73,13 @@ class Main : AbstractMain
   
   Int parseFandoc()
   {
-    readInput
-    return 0
+    buf := getOutputBuffer( "md" )
+    fandocDoc := FandocParser().parse( srcFile.name, srcFile.in )
+    log.info( "Fandoc file parsed" )
+    fandocDoc.write( MarkdownDocWriter( buf.out ) )
+    log.debug( buf.toStr )
+    log.info( "Done" )
+    return buf.close ? 0 : -1
   }
   
 }

--- a/fan/Main.fan
+++ b/fan/Main.fan
@@ -1,0 +1,60 @@
+using util
+using fandoc
+
+class Main : AbstractMain
+{
+  
+  @Arg { help = "Source Markdown (.md) or Fandoc (.fandoc) file to convert." }
+  File? srcFile
+  
+  @Opt { aliases=["l"]; help = "Sets the logging level to any of [silent, err, warn, info, debug]." }
+  LogLevel loggingLevel := LogLevel.info
+  
+  
+  
+  override Int run()
+  {
+    log.level = loggingLevel
+    
+    ext := srcFile.ext
+    if( ext == null ) { throw Err( "Source file must have either .md (Markdown) or .fandoc (Fandoc) extension." ) }
+    
+        mdLines := srcFile.open( "r" ).readAllLines
+    content := ""
+    mdLines.each {
+      content = content + "\r\n" + it
+    }
+    
+    log.debug( content )
+    
+    exitCode := 0
+   
+    switch( ext.lower )
+    {
+      case "md": exitCode = parseMarkdown( content )
+      case "fandoc": exitCode = parseFandoc( content )
+      default: throw Err( "Unsupported file extension: .${ext}; only .md and .fandoc files are supported." )
+    }
+    return exitCode
+  }
+  
+  
+  Int parseMarkdown( Str mdContent )
+  {
+    markdownDoc := MarkdownParser().parse( mdContent )
+    
+    buf := StrBuf()
+    markdownDoc.write( FandocDocWriter( buf.out ) )
+
+    log.info( buf.toStr )
+    return 0
+  }
+  
+  
+  Int parseFandoc( Str fandocContent )
+  {
+    log.info( fandocContent )
+    return 0
+  }
+  
+}


### PR DESCRIPTION
Added `Main` class with `main()` method for converting Markdown files to Fandoc and vice versa from the command line.

### Usage:
  `afMarkdownParser [options] <srcFile> <targetFile>*`
#### Arguments:
*  `srcFile`
    Source Markdown (.md) or Fandoc (.fandoc) file to convert.
*  `targetFile` (optional)
    Name of the destination file. Defaults to source filename with the opposite extension.
#### Options:
  `-help`, `-?`             Print usage help
  `-overwrite`, `-o`        Overwrite target file if exists. By default aborts the process if the target file exists.
  `-logLevel`, `-l` `<LogLevel>`  Sets the logging level to any of `silent`, `err`, `warn`, `info`, `debug`. Defaults to `info`
